### PR TITLE
Prevent fatal error caused by missing method

### DIFF
--- a/admin/class-cf7-polylang-admin.php
+++ b/admin/class-cf7-polylang-admin.php
@@ -458,7 +458,8 @@ class Cf7_Polylang_Admin {
 			return;
 		}
 		//let's reset the textdomain
-		$this->load_plugin_textdomain();
+		$i18n = new Cf7_Polylang_i18n();
+		$i18n->load_plugin_textdomain();
 	}
   /**
    * Redirect to new table list on form delete


### PR DESCRIPTION
`Fatal error: Call to undefined method Cf7_Polylang_Admin::load_plugin_textdomain()`